### PR TITLE
setup thoth release bot for opfcli

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is and how often it occurs
+
+**Steps To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Workaround (if any)**
+Any manual steps that allow you to resolve the issue
+
+**Open Data Hub Version**
+Please attach relevant kfdef manifest if applicable
+
+**OpenShift Version**
+Version #:
+Provider (Baremetal, OpenStack, RHV, AWS, OKD, CodeReady Containers, ...):
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Example. Instead of [CURRENT FEATURE], I think it would be helpful to implement [EXPLANATION OF NEW FEATURE].
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/major-release.md
+++ b/.github/ISSUE_TEMPLATE/major-release.md
@@ -1,0 +1,11 @@
+---
+name: Major release
+about: Create a new major release
+title: New major release
+assignees: 'sesheta'
+labels: bot
+---
+
+Hey, Kebechet!
+
+Create a new major release, please.

--- a/.github/ISSUE_TEMPLATE/minor-release.md
+++ b/.github/ISSUE_TEMPLATE/minor-release.md
@@ -1,0 +1,11 @@
+---
+name: Minor release
+about: Create a new minor release
+title: New minor release
+assignees: 'sesheta'
+labels: bot
+---
+
+Hey, Kebechet!
+
+Create a new minor release, please.

--- a/.github/ISSUE_TEMPLATE/patch-release.md
+++ b/.github/ISSUE_TEMPLATE/patch-release.md
@@ -1,0 +1,11 @@
+---
+name: Patch release
+about: Create a new patch release
+title: New patch release
+assignees: 'sesheta'
+labels: bot
+---
+
+Hey, Kebechet!
+
+Create a new patch release, please.

--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -1,0 +1,12 @@
+managers:
+  - name: version
+    configuration:
+      maintainers:
+        - larsks
+        - HumairAK
+        - tumido
+        - 4n4nd
+      assignees:
+        - sesheta
+      labels: [bot]
+      changelog_file: true

--- a/version.py
+++ b/version.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+"""This file is just for the release bots to track opfcli release"""
+
+
+__version__ = "0.0.0"


### PR DESCRIPTION
setup thoth release bot for opfcli
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

- People defined in `.thoth.yaml` would be the maintainer and can utilize the release bot.
- Patch|minor|major release can be made with request via issues. 
- version.py is used by the bot to keep track of the versions it releases. 