### PR TITLE
Add tests for cmd module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,13 @@ $(EXE): $(SRCS)
 	go build -o $@ -ldflags "$(GOLDFLAGS)"
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) coverage.html coverage.txt coverage.out
+
+coverage.html: coverage.out
+	go tool cover -html $< -o $@
+
+coverage.txt: coverage.out
+	go tool cover -func $< -o $@
+
+coverage.out: $(SRCS)
+	go test -coverprofile=$@ ./...

--- a/cmd/createGroup_test.go
+++ b/cmd/createGroup_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import "github.com/stretchr/testify/require"
+
+func (suite *commandTestSuite) TestCreateGroup() {
+	assert := require.New(suite.T())
+
+	// Should fail with too few args
+	cmd := NewCmdCreateGroup(suite.api)
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.EqualError(err, "accepts 1 arg(s), received 0")
+
+	// ---
+
+	// Should fail with too many args
+	cmd = NewCmdCreateGroup(suite.api)
+	cmd.SetArgs([]string{"arg1", "arg2"})
+	err = cmd.Execute()
+	assert.EqualError(err, "accepts 1 arg(s), received 2")
+
+	// ---
+
+	// Should fail with unknown option
+	cmd = NewCmdCreateGroup(suite.api)
+	cmd.SetArgs([]string{"--failure", "arg1"})
+	err = cmd.Execute()
+	assert.EqualError(err, "unknown flag: --failure")
+
+	// ---
+
+	// Should succeed
+	cmd = NewCmdCreateGroup(suite.api)
+	cmd.SetArgs([]string{"arg1"})
+	err = cmd.Execute()
+	assert.Nil(err)
+}

--- a/cmd/createProject_test.go
+++ b/cmd/createProject_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/operate-first/opfcli/constants"
+	"github.com/stretchr/testify/require"
+)
+
+func (suite *commandTestSuite) TestCreateProjectBasic() {
+	assert := require.New(suite.T())
+
+	// Should fail with too few args
+	cmd := NewCmdCreateProject(suite.api)
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.EqualError(err, "accepts 2 arg(s), received 0")
+
+	// ---
+
+	// Should fail with too many args
+	cmd = NewCmdCreateProject(suite.api)
+	cmd.SetArgs([]string{"arg1", "arg2", "arg3"})
+	err = cmd.Execute()
+	assert.EqualError(err, "accepts 2 arg(s), received 3")
+
+	// ---
+
+	// Should fail with unknown option
+	cmd = NewCmdCreateProject(suite.api)
+	cmd.SetArgs([]string{"--failure", "arg1", "arg2"})
+	err = cmd.Execute()
+	assert.EqualError(err, "unknown flag: --failure")
+
+	// ---
+
+	// Should succeed
+	cmd = NewCmdCreateProject(suite.api)
+	cmd.SetArgs([]string{"arg1", "arg2"})
+	err = cmd.Execute()
+	assert.Nil(err)
+
+	// ---
+
+	// Should fail because group already exists
+	cmd = NewCmdCreateProject(suite.api)
+	cmd.SetArgs([]string{"arg1", "arg2"})
+	err = cmd.Execute()
+	assert.EqualError(err, "group arg2 already exists")
+}
+
+func (suite *commandTestSuite) TestCreateProjectQuota() {
+	assert := require.New(suite.T())
+
+	// Should fail because quota does not exist
+	cmd := NewCmdCreateProject(suite.api)
+	cmd.SetArgs([]string{"-q", "testquota", "arg1", "arg2"})
+	err := cmd.Execute()
+	assert.EqualError(err, "quota testquota does not exist")
+
+	// ---
+
+	err = os.MkdirAll(filepath.Join(
+		suite.api.RepoDirectory,
+		suite.api.AppName,
+		constants.ComponentPath,
+		"resourcequotas",
+		"testquota",
+	), 0755)
+	assert.Nil(err)
+
+	// Should succeed
+	cmd = NewCmdCreateProject(suite.api)
+	cmd.SetArgs([]string{"-q", "testquota", "arg1", "arg2"})
+	err = cmd.Execute()
+	assert.Nil(err)
+}

--- a/cmd/enableMonitoring_test.go
+++ b/cmd/enableMonitoring_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/operate-first/opfcli/constants"
+	"github.com/stretchr/testify/require"
+)
+
+func (suite *commandTestSuite) TestEnableMonitoring() {
+	assert := require.New(suite.T())
+
+	// Should fail with too few args
+	cmd := NewCmdEnableMonitoring(suite.api)
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.EqualError(err, "accepts 1 arg(s), received 0")
+
+	// ---
+
+	// Should fail with too many args
+	cmd = NewCmdEnableMonitoring(suite.api)
+	cmd.SetArgs([]string{"arg1", "arg2"})
+	err = cmd.Execute()
+	assert.EqualError(err, "accepts 1 arg(s), received 2")
+
+	// ---
+
+	// Should fail because namespace does not exist
+	cmd = NewCmdEnableMonitoring(suite.api)
+	cmd.SetArgs([]string{"arg1"})
+	err = cmd.Execute()
+	assert.EqualError(err, "namespace arg1 does not exist")
+
+	// ---
+
+	err = os.MkdirAll(filepath.Join(
+		suite.api.RepoDirectory,
+		suite.api.AppName,
+		constants.NamespacePath,
+		"arg1",
+	), 0755)
+	assert.Nil(err)
+
+	// Should fail because component does not exist
+	cmd = NewCmdEnableMonitoring(suite.api)
+	cmd.SetArgs([]string{"arg1"})
+	err = cmd.Execute()
+	assert.EqualError(err, "component monitoring-rbac does not exist")
+
+	// ---
+
+	err = os.MkdirAll(filepath.Join(
+		suite.api.RepoDirectory,
+		suite.api.AppName,
+		constants.ComponentPath,
+		"monitoring-rbac",
+	), 0755)
+	assert.Nil(err)
+
+	// Should fail due to missing kustomization.yaml
+	cmd = NewCmdEnableMonitoring(suite.api)
+	cmd.SetArgs([]string{"arg1"})
+	err = cmd.Execute()
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "kustomization.yaml: no such file or directory")
+}

--- a/cmd/grantAccess_test.go
+++ b/cmd/grantAccess_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import "github.com/stretchr/testify/require"
+
+func (suite *commandTestSuite) TestGrantAccess() {
+	assert := require.New(suite.T())
+
+	// Should fail with too few args
+	cmd := NewCmdGrantAccess(suite.api)
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.EqualError(err, "accepts 3 arg(s), received 0")
+
+	// ---
+
+	// Should fail with too many args
+	cmd = NewCmdGrantAccess(suite.api)
+	cmd.SetArgs([]string{"arg1", "arg2", "arg3", "arg4"})
+	err = cmd.Execute()
+	assert.EqualError(err, "accepts 3 arg(s), received 4")
+
+	// ---
+
+	// Should fail with unknown option
+	cmd = NewCmdGrantAccess(suite.api)
+	cmd.SetArgs([]string{"--failure", "arg1", "arg2", "arg3", "arg4"})
+	err = cmd.Execute()
+	assert.EqualError(err, "unknown flag: --failure")
+
+	// ---
+
+	// Should fail because role is missing
+	cmd = NewCmdGrantAccess(suite.api)
+	cmd.SetArgs([]string{"arg1", "arg2", "arg3"})
+	err = cmd.Execute()
+	assert.EqualError(err, "role arg3 does not exist")
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,14 +13,6 @@ import (
 )
 
 func initConfig(cmd *cobra.Command, opfapi *api.API, config *viper.Viper) error {
-	if err := config.BindPFlag("app-name", cmd.Flags().Lookup("app-name")); err != nil {
-		log.Fatalf("failed to bind flag app-name: %v", err)
-	}
-
-	if err := config.BindPFlag("repo-dir", cmd.Flags().Lookup("repo-dir")); err != nil {
-		log.Fatalf("failed to bind flag repo-dir: %v", err)
-	}
-
 	cfgFile, err := cmd.Flags().GetString("config-file")
 	if err != nil {
 		return err
@@ -96,6 +88,14 @@ configuration repository.`,
 		"app-name", "a", "cluster-scope", "application name")
 	cmd.PersistentFlags().StringP(
 		"repo-dir", "r", "", "path to opf repository")
+
+	if err := config.BindPFlag("app-name", cmd.PersistentFlags().Lookup("app-name")); err != nil {
+		log.Fatalf("failed to bind flag app-name: %v", err)
+	}
+
+	if err := config.BindPFlag("repo-dir", cmd.PersistentFlags().Lookup("repo-dir")); err != nil {
+		log.Fatalf("failed to bind flag repo-dir: %v", err)
+	}
 
 	cmd.AddCommand(
 		NewCmdVersion(opfapi),

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/operate-first/opfcli/api"
+	"github.com/operate-first/opfcli/utils"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type commandTestSuite struct {
+	suite.Suite
+	dir string
+	api *api.API
+}
+
+func TestCommands(t *testing.T) {
+	utils.ConfigureLogging()
+	suite.Run(t, new(commandTestSuite))
+}
+
+func (suite *commandTestSuite) SetupTest() {
+	suite.dir = suite.T().TempDir()
+	suite.api = api.New("cluster-scope", suite.dir)
+}
+
+func (suite *commandTestSuite) TestRoot() {
+	assert := require.New(suite.T())
+
+	// should fail with unknown command
+	cmd := NewCmdRoot()
+	cmd.SetArgs([]string{"testcommand"})
+	err := cmd.Execute()
+	assert.Contains(err.Error(), "unknown command")
+
+	// ---
+
+	// should fail with unknown option
+	cmd = NewCmdRoot()
+	cmd.SetArgs([]string{"--failure"})
+	err = cmd.Execute()
+	assert.EqualError(err, "unknown flag: --failure")
+
+	// ---
+
+	// --repo-dir should set repo-dir
+	cmd = NewCmdRoot()
+	cmd.SetArgs([]string{"--repo-dir", suite.dir})
+	err = cmd.Execute()
+	assert.Nil(err)
+	val, err := cmd.Flags().GetString("repo-dir")
+	assert.Nil(err)
+	assert.Equal(val, suite.dir)
+
+	// ---
+
+	// --app-name should set app-name
+	cmd = NewCmdRoot()
+	cmd.SetArgs([]string{"--app-name", "testname"})
+	err = cmd.Execute()
+	assert.Nil(err)
+	val, err = cmd.Flags().GetString("app-name")
+	assert.Nil(err)
+	assert.Equal(val, "testname")
+
+	// ---
+
+	// Should succeed with known command
+	cmd = NewCmdRoot()
+	cmd.SetArgs([]string{"version"})
+	err = cmd.Execute()
+	assert.Nil(err)
+}


### PR DESCRIPTION
- Add some basic tests for subcommands. These primarily test responses
  to valid and invalid options.
- Add coverage targets to Makefile

Depends on #10
Depends on #11 
Depends on #12 
