### PR TITLE
Build image now uses ubi8 instead of Fedora 34

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # https://github.com/larsks/opf-go-precommit
-      image: quay.io/larsks/opf-go-precommit:d3dc2d2
+      image: quay.io/larsks/opf-go-precommit:6fb0601
       env:
         XDG_CACHE_HOME: /cache
         GOCACHE: /cache/go-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # https://github.com/larsks/opf-go-precommit
-      image: quay.io/larsks/opf-go-precommit:d3dc2d2
+      image: quay.io/larsks/opf-go-precommit:6fb0601
       env:
         XDG_CACHE_HOME: /cache
         GOCACHE: /cache/go-build


### PR DESCRIPTION
Closes #14

x-branch: feature/backwards-compat