### PR TITLE
Build image now *really* uses ubi8 instead of Fedora 34 (#15)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
             goarch: arm
     container:
       # https://github.com/larsks/opf-go-precommit
-      image: quay.io/larsks/opf-go-precommit:d3dc2d2
+      image: quay.io/larsks/opf-go-precommit:6fb0601
       env:
         XDG_CACHE_HOME: /cache
         GOCACHE: /cache/go-build


### PR DESCRIPTION
The previous commit changed the image for the pre-commit tests, but
not for the actual build job. Whoops.

Closes #14

x-branch: feature/backwards-compat
