### PR TITLE
Drop darwin-arm64 from release build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,10 @@ jobs:
         exclude:
           - goos: darwin
             goarch: arm
+
+          # This requires go 1.16
+          - goos: darwin
+            goarch: arm64
     container:
       # https://github.com/larsks/opf-go-precommit
       image: quay.io/larsks/opf-go-precommit:6fb0601


### PR DESCRIPTION
Go 1.15 won't build darwin-arm64 binaries.

This is the simplest solution to #17 while we figure out a better long
term strategy.
