### PR TITLE
fix: Allow namespace creation if group already exists

### DIFF
--- a/api/CreateProject.go
+++ b/api/CreateProject.go
@@ -41,7 +41,7 @@ func (api *API) CreateProject(
 
 	if err := api.CreateGroup(
 		projectOwner,
-		false,
+		true,
 	); err != nil {
 		return err
 	}

--- a/api/CreateProject_test.go
+++ b/api/CreateProject_test.go
@@ -31,6 +31,32 @@ func (suite *apiTestSuite) TestCreateProject() {
 	compareWithExpected(assert, "testdata/CreateProject", suite.dir, expectedPaths)
 }
 
+func (suite *apiTestSuite) TestCreateProjectWhenGroupExists() {
+	assert := require.New(suite.T())
+
+	err := suite.api.CreateGroup("testgroup", false)
+	assert.Nil(err)
+
+	err = suite.api.CreateProject(
+		"testproject",
+		"testgroup",
+		"test description",
+		"",
+		false,
+	)
+	assert.Nil(err)
+
+	expectedPaths := []string{
+		"cluster-scope/base/core/namespaces/testproject/namespace.yaml",
+		"cluster-scope/base/core/namespaces/testproject/kustomization.yaml",
+		"cluster-scope/base/user.openshift.io/groups/testgroup/group.yaml",
+		"cluster-scope/base/user.openshift.io/groups/testgroup/kustomization.yaml",
+		"cluster-scope/components/project-admin-rolebindings/testgroup/rbac.yaml",
+	}
+
+	compareWithExpected(assert, "testdata/CreateProject", suite.dir, expectedPaths)
+}
+
 func (suite *apiTestSuite) TestCreateProjectQuota() {
 	assert := require.New(suite.T())
 

--- a/cmd/createProject_test.go
+++ b/cmd/createProject_test.go
@@ -43,11 +43,11 @@ func (suite *commandTestSuite) TestCreateProjectBasic() {
 
 	// ---
 
-	// Should fail because group already exists
+	// Should succeed if group already exists
 	cmd = NewCmdCreateProject(suite.api)
-	cmd.SetArgs([]string{"arg1", "arg2"})
+	cmd.SetArgs([]string{"arg3", "arg2"})
 	err = cmd.Execute()
-	assert.EqualError(err, "group arg2 already exists")
+	assert.Nil(err)
 }
 
 func (suite *commandTestSuite) TestCreateProjectQuota() {


### PR DESCRIPTION
Resolves: #19

`create-project` fails if an user group already exists. For some reason this was intentionally disabled and even tested, but I think we need to have a way to allow new namespaces to be created even if the group already exists.