### PR TITLE
Updating pre-commit repo uri protocol to https.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.3.0
     hooks:
       - id: trailing-whitespace
@@ -20,7 +20,7 @@ repos:
         types: [file, yaml]
         entry: yamllint --strict
 
-  - repo: git://github.com/dnephin/pre-commit-golang
+  - repo: https://github.com/dnephin/pre-commit-golang
     rev: f780b51bd3
     hooks:
       - id: go-fmt


### PR DESCRIPTION
To resolve this error: 
```
 [INFO] Initializing environment for git://github.com/pre-commit/pre-commit-hooks.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    fatal: remote error: 
      The unauthenticated git protocol on port 9418 is no longer supported.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
    
Check the log at /cache/pre-commit/pre-commit.log
Error: Process completed with exit code 3.
```

https://github.com/operate-first/opfcli/runs/5681114851?check_suite_focus=true