### PR TITLE
Implement ability to add one or multiple user(s) to group

### DIFF
--- a/api/AddUsersToGroup.go
+++ b/api/AddUsersToGroup.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/operate-first/opfcli/constants"
+	"github.com/operate-first/opfcli/models"
+	"github.com/operate-first/opfcli/utils"
+)
+
+func (api *API) AddUsersToGroup(groupName string, users []string) error {
+
+	groupPath := filepath.Join(api.RepoDirectory, api.AppName, constants.GroupPath, groupName, "group.yaml")
+	exists, err := utils.PathExists(filepath.Dir(groupPath))
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("group %s does not exist", groupName)
+	}
+
+	err = models.AddUsersToGroup(filepath.Dir(groupPath), users)
+	if err != nil {
+		return err
+	}
+
+	commonOverlayPath := filepath.Join(api.RepoDirectory, api.AppName, constants.CommonOverlayPath)
+	commonOverlayKustomizationPath := filepath.Join(commonOverlayPath, "kustomization.yaml")
+	groupPath = fmt.Sprintf("../../../base/user.openshift.io/groups/%s", groupName)
+
+	exist, err := utils.PathExists(commonOverlayKustomizationPath)
+	if err != nil {
+		return fmt.Errorf("encountered error when trying to verify kustomization in common overlay path: %s", commonOverlayKustomizationPath)
+	} else if !exist {
+		return fmt.Errorf("kustomization does not exist in common overlay path: %s", commonOverlayKustomizationPath)
+	}
+
+	kustom, err := models.KustomizeFromYAMLPath(commonOverlayKustomizationPath)
+	if err != nil {
+		return err
+	}
+
+	groupFound := false
+	for _, resource := range kustom.Resources {
+		if resource == groupPath {
+			groupFound = true
+			break
+		}
+	}
+
+	if !groupFound {
+		err = utils.AddKustomizeResources(commonOverlayPath, []string{groupPath})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
+}

--- a/api/AddUsersToGroup_test.go
+++ b/api/AddUsersToGroup_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/operate-first/opfcli/constants"
+	"github.com/operate-first/opfcli/models"
+	"github.com/operate-first/opfcli/utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func (suite *apiTestSuite) TestAddUsersToGroup() {
+	assert := require.New(suite.T())
+
+	err := suite.api.AddUsersToGroup("testgroup", []string{"testuser1", "testuser2"})
+	assert.EqualError(err, "group testgroup does not exist")
+
+	err = suite.api.CreateGroup("testgroup", []string{"testuser1"}, true)
+	assert.Nil(err)
+
+	commonOverlayPath := filepath.Join(suite.api.RepoDirectory, suite.api.AppName, constants.CommonOverlayPath)
+	commonOverlayKustomizationPath := filepath.Join(commonOverlayPath, "kustomization.yaml")
+
+	err = suite.api.AddUsersToGroup("testgroup", []string{"testuser1", "testuser2"})
+	assert.EqualError(err, fmt.Sprintf("kustomization does not exist in common overlay path: %s", commonOverlayKustomizationPath))
+
+	commonOverlayPathExists, err := utils.PathExists(commonOverlayPath)
+	assert.Nil(err)
+	if !commonOverlayPathExists {
+		log.Printf("Common overlay kustomization must exist, to deploy group to cluster.")
+		err = os.MkdirAll(commonOverlayPath, 0755)
+		assert.Nil(err)
+	}
+	commonOverlayKustomizationExists, err := utils.PathExists(commonOverlayKustomizationPath)
+	assert.Nil(err)
+	if !commonOverlayKustomizationExists {
+		kustom := models.NewKustomization([]string{"../../../base"}, nil, "")
+		err = utils.WriteKustomization(commonOverlayPath, kustom)
+		assert.Nil(err)
+	}
+
+	err = suite.api.AddUsersToGroup("testgroup", []string{"testuser2", "testuser3"})
+	assert.Nil(err)
+
+	expectedPaths := []string{
+		"cluster-scope/base/user.openshift.io/groups/testgroup/kustomization.yaml",
+		"cluster-scope/base/user.openshift.io/groups/testgroup/group.yaml",
+	}
+
+	compareWithExpected(assert, "testdata/AddUsersToGroup", suite.dir, expectedPaths)
+
+}

--- a/api/testdata/AddUsersToGroup/cluster-scope/base/user.openshift.io/groups/testgroup/group.yaml
+++ b/api/testdata/AddUsersToGroup/cluster-scope/base/user.openshift.io/groups/testgroup/group.yaml
@@ -1,0 +1,8 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: testgroup
+users:
+  - testuser1
+  - testuser2
+  - testuser3

--- a/api/testdata/AddUsersToGroup/cluster-scope/base/user.openshift.io/groups/testgroup/kustomization.yaml
+++ b/api/testdata/AddUsersToGroup/cluster-scope/base/user.openshift.io/groups/testgroup/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - group.yaml

--- a/api/testdata/AddUsersToGroup/cluster-scope/overlay/prod/common/kustomization.yaml
+++ b/api/testdata/AddUsersToGroup/cluster-scope/overlay/prod/common/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../base
+- ../../../base/user.openshift.io/groups/testgroup

--- a/cmd/addUsersToGroup.go
+++ b/cmd/addUsersToGroup.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/operate-first/opfcli/api"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdAddUsersToGroup(opfapi *api.API) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "add-users group users cluster",
+		Short:         "Add users to a group",
+		Long:          `Add a comma seperated list of github handles to a group.`,
+		Args:          cobra.ExactArgs(2),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			users := strings.Split(args[1], ",")
+			return opfapi.AddUsersToGroup(args[0], users)
+		},
+	}
+	return cmd
+}

--- a/cmd/addUsersToGroup_test.go
+++ b/cmd/addUsersToGroup_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/operate-first/opfcli/constants"
+	"github.com/operate-first/opfcli/models"
+	"github.com/operate-first/opfcli/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func (suite *commandTestSuite) TestAddUsersToGroup() {
+	assert := require.New(suite.T())
+
+	// Should fail with too few args
+	cmd := NewCmdAddUsersToGroup(suite.api)
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.EqualError(err, "accepts 2 arg(s), received 0")
+
+	// ---
+
+	// Should fail with too many args
+	cmd = NewCmdAddUsersToGroup(suite.api)
+	cmd.SetArgs([]string{"arg1", "arg2", "arg3", "arg4", "arg5"})
+	err = cmd.Execute()
+	assert.EqualError(err, "accepts 2 arg(s), received 5")
+
+	// ---
+
+	// Should fail with unknown option
+	cmd = NewCmdAddUsersToGroup(suite.api)
+	cmd.SetArgs([]string{"--failure", "arg1"})
+	err = cmd.Execute()
+	assert.EqualError(err, "unknown flag: --failure")
+
+	// ---
+
+	// Should fail if group does not exist
+	cmd = NewCmdAddUsersToGroup(suite.api)
+	cmd.SetArgs([]string{"arg1", "user1, user2, user3"})
+	err = cmd.Execute()
+	assert.EqualError(err, "group arg1 does not exist")
+
+	//  create group
+
+	err = suite.api.CreateGroup(
+		"testgroup",
+		[]string{},
+		true,
+	)
+	assert.Nil(err)
+
+	// create core common kustomization
+	commonOverlayPath := filepath.Join(suite.api.RepoDirectory, suite.api.AppName, constants.CommonOverlayPath)
+	err = os.MkdirAll(commonOverlayPath, 0755)
+	assert.Nil(err)
+	kustom := models.NewKustomization([]string{"../../../base"}, nil, "")
+	err = utils.WriteKustomization(commonOverlayPath, kustom)
+	assert.Nil(err)
+
+	cmd = NewCmdAddUsersToGroup(suite.api)
+	cmd.SetArgs([]string{"testgroup", "user1, user2, user3"})
+	err = cmd.Execute()
+	assert.Nil(err)
+
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -105,6 +105,7 @@ configuration repository.`,
 		NewCmdEnableMonitoring(opfapi),
 		NewCmdInstallOperator(opfapi),
 		NewCmdOnboard(opfapi),
+		NewCmdAddUsersToGroup(opfapi),
 		NewCmdCompletion(),
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,5 @@ require (
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	sigs.k8s.io/kustomize/api v0.11.2
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/models/group.go
+++ b/models/group.go
@@ -1,7 +1,15 @@
 package models
 
 import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+	"sort"
+	"strings"
+
 	log "github.com/sirupsen/logrus"
+	yaml "sigs.k8s.io/yaml"
 )
 
 // Group represents a group of users.
@@ -27,4 +35,84 @@ func NewGroup(name string, users []string) Group {
 		Users: users,
 	}
 	return rsrc
+}
+
+func (g *Group) Unmarshal(y []byte) error {
+	j, err := yaml.YAMLToJSON(y)
+	if err != nil {
+		return err
+	}
+	dec := json.NewDecoder(bytes.NewReader(j))
+	dec.DisallowUnknownFields()
+	var ng Group
+	err = dec.Decode(&ng)
+	if err != nil {
+		return err
+	}
+	*g = ng
+	return nil
+}
+
+func GroupFromYamlPath(path string) (Group, error) {
+	var group Group
+
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return group, err
+	}
+
+	err = group.Unmarshal(content)
+	if err != nil {
+		return Group{}, err
+	}
+
+	return group, nil
+}
+
+func SortGroup(group Group) Group {
+	users := make([]string, len(group.Users))
+	copy(users, group.Users)
+	if len(users) > 0 {
+		if !sort.StringsAreSorted(users) {
+			sort.Strings(users)
+		}
+	}
+	return Group{
+		Resource: group.Resource,
+		Users:    users,
+	}
+}
+
+func AddUsersToGroup(path string, users []string) error {
+	groupPath := filepath.Join(path, "group.yaml")
+	log.Debugf("updating kustomization for %s", path)
+	group, err := GroupFromYamlPath(groupPath)
+	if err != nil {
+		return err
+	}
+
+	for _, userToAdd := range users {
+		userToAdd = strings.Trim(userToAdd, " ")
+		flagContainsUser := false
+		for _, user := range group.Users {
+			if user == userToAdd {
+				flagContainsUser = true
+			}
+		}
+		if !flagContainsUser {
+			group.Users = append(group.Users, userToAdd)
+		}
+	}
+	groupSorted := SortGroup(group)
+
+	groupOut, err := ToYAML(groupSorted)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(groupPath, groupOut, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
In response to slack conversation in `Operate-first` #support channel today (thanks for the suggestion @durandom).

Partially Addresses: https://github.com/operate-first/opfcli/issues/46
Partially Addresses: https://github.com/operate-first/opfcli/issues/28

AddUsersToGroup cmd, api, group model changes, and importing yaml package.
Yaml package is imported for creating unmarshal function similar to the one native to the kustomization api type, but for `operate-first/opfcli` defined group struct.

/cc @HumairAK @larsks 
