### PR TITLE
update onboard to include relevant project information

### DIFF
--- a/api/AddComponent_test.go
+++ b/api/AddComponent_test.go
@@ -27,6 +27,8 @@ func (suite *apiTestSuite) TestAddComponent() {
 		"",
 		false,
 		false,
+		"",
+		"",
 	)
 	assert.Nil(err)
 

--- a/api/CreateNamespace.go
+++ b/api/CreateNamespace.go
@@ -13,10 +13,14 @@ import (
 )
 
 func (api *API) CreateNamespace(
-	projectName, projectOwner, projectDisplayName string,
+	projectName string,
+	projectOwner string,
+	projectDisplayName string,
 	projectQuota string,
 	disableLimitrange bool,
 	existsOk bool,
+	onboardingIssue string,
+	docs string,
 ) error {
 	path := filepath.Join(
 		api.RepoDirectory, api.AppName,
@@ -30,6 +34,7 @@ func (api *API) CreateNamespace(
 	if exists {
 		if existsOk {
 			log.Warnf("namespace %s already exists (continuing)", projectName)
+			// check if onboardingIssue and docs are set
 			return nil
 		}
 		return fmt.Errorf("namespace %s already exists", projectName)
@@ -63,7 +68,7 @@ func (api *API) CreateNamespace(
 			))
 	}
 
-	ns := models.NewNamespace(projectName, projectOwner, projectDisplayName)
+	ns := models.NewNamespace(projectName, projectOwner, projectDisplayName, onboardingIssue, docs)
 	nsOut, err := models.ToYAML(ns)
 	if err != nil {
 		return err

--- a/api/CreateNamespace_test.go
+++ b/api/CreateNamespace_test.go
@@ -12,6 +12,8 @@ func (suite *apiTestSuite) TestCreateNamespace() {
 		"",
 		false,
 		false,
+		"",
+		"",
 	)
 	assert.Nil(err)
 
@@ -33,6 +35,8 @@ func (suite *apiTestSuite) TestCreateNamespaceExistsOk() {
 		"",
 		false,
 		false,
+		"",
+		"",
 	)
 	assert.Nil(err)
 
@@ -43,6 +47,8 @@ func (suite *apiTestSuite) TestCreateNamespaceExistsOk() {
 		"",
 		false,
 		true,
+		"",
+		"",
 	)
 	assert.Nil(err)
 
@@ -64,6 +70,8 @@ func (suite *apiTestSuite) TestCreateNamespaceExistsNotOk() {
 		"",
 		false,
 		false,
+		"",
+		"",
 	)
 	assert.Nil(err)
 
@@ -74,6 +82,8 @@ func (suite *apiTestSuite) TestCreateNamespaceExistsNotOk() {
 		"",
 		false,
 		false,
+		"",
+		"",
 	)
 	assert.EqualError(err, "namespace testproject already exists")
 
@@ -96,11 +106,14 @@ func (suite *apiTestSuite) TestCreateNamespaceQuota() {
 		"testquota",
 		false,
 		false,
+		"",
+		"",
 	)
 	assert.Nil(err)
 
 	expectedPaths := []string{
 		"cluster-scope/base/core/namespaces/testproject/kustomization.yaml",
+		"cluster-scope/base/core/namespaces/testproject/namespace.yaml",
 	}
 
 	compareWithExpected(assert, "testdata/CreateNamespaceQuota", suite.dir, expectedPaths)
@@ -109,7 +122,7 @@ func (suite *apiTestSuite) TestCreateNamespaceQuota() {
 func (suite *apiTestSuite) TestCreateNamespaceNoLimitrange() {
 	assert := require.New(suite.T())
 
-	// Should fail if quota doesn't exist
+	// Should suceed with no limit range
 	err := suite.api.CreateNamespace(
 		"testproject",
 		"testgroup",
@@ -117,12 +130,39 @@ func (suite *apiTestSuite) TestCreateNamespaceNoLimitrange() {
 		"",
 		true,
 		false,
+		"",
+		"",
 	)
 	assert.Nil(err)
 
 	expectedPaths := []string{
 		"cluster-scope/base/core/namespaces/testproject/kustomization.yaml",
+		"cluster-scope/base/core/namespaces/testproject/namespace.yaml",
 	}
 
 	compareWithExpected(assert, "testdata/CreateNamespaceNoLimitrange", suite.dir, expectedPaths)
+}
+
+func (suite *apiTestSuite) TestCreateNamespaceWithProjectDetails() {
+	assert := require.New(suite.T())
+
+	// Should succeed
+	err := suite.api.CreateNamespace(
+		"testproject",
+		"testgroup",
+		"test display name",
+		"",
+		true,
+		false,
+		"https://github.com/operate-first/support/issues/414141",
+		"https://www.operate-first.cloud",
+	)
+	assert.Nil(err)
+
+	expectedPaths := []string{
+		"cluster-scope/base/core/namespaces/testproject/kustomization.yaml",
+		"cluster-scope/base/core/namespaces/testproject/namespace.yaml",
+	}
+
+	compareWithExpected(assert, "testdata/CreateNamespaceWithProjectDetails", suite.dir, expectedPaths)
 }

--- a/api/CreateProject.go
+++ b/api/CreateProject.go
@@ -58,5 +58,7 @@ func (api *API) CreateProject(
 		projectQuota,
 		disableLimitrange,
 		false,
+		"",
+		"",
 	)
 }

--- a/api/Onboard.go
+++ b/api/Onboard.go
@@ -50,6 +50,8 @@ func (api *API) Onboard(path string) error {
 			tempQuota,
 			onboardRequest.Namespaces[i].DisableLimitRange,
 			true,
+			onboardRequest.OnboardingIssue,
+			onboardRequest.Docs,
 		); err != nil {
 			return err
 		}

--- a/api/testdata/CreateNamespaceNoLimitrange/cluster-scope/base/core/namespaces/testproject/namespace.yaml
+++ b/api/testdata/CreateNamespaceNoLimitrange/cluster-scope/base/core/namespaces/testproject/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: testproject
+    annotations:
+        openshift.io/requester: testgroup
+        openshift.io/display-name: test display name

--- a/api/testdata/CreateNamespaceQuota/cluster-scope/base/core/namespaces/testproject/namespace.yaml
+++ b/api/testdata/CreateNamespaceQuota/cluster-scope/base/core/namespaces/testproject/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: testproject
+    annotations:
+        openshift.io/requester: testgroup
+        openshift.io/display-name: test display name

--- a/api/testdata/CreateNamespaceWithProjectDetails/cluster-scope/base/core/namespaces/testproject/kustomization.yaml
+++ b/api/testdata/CreateNamespaceWithProjectDetails/cluster-scope/base/core/namespaces/testproject/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: testproject
+resources:
+    - namespace.yaml
+components:
+    - ../../../../components/project-admin-rolebindings/testgroup

--- a/api/testdata/CreateNamespaceWithProjectDetails/cluster-scope/base/core/namespaces/testproject/namespace.yaml
+++ b/api/testdata/CreateNamespaceWithProjectDetails/cluster-scope/base/core/namespaces/testproject/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: testproject
+    annotations:
+        openshift.io/display-name: test display name
+        openshift.io/requester: testgroup
+        op1st/project-owner: testgroup
+        op1st/onboarding-issue: "https://github.com/operate-first/support/issues/414141"
+        op1st/docs: "https://www.operate-first.cloud"

--- a/api/testdata/Onboard/sampleOnboardConfigWithProjectDetails.yaml
+++ b/api/testdata/Onboard/sampleOnboardConfigWithProjectDetails.yaml
@@ -1,0 +1,9 @@
+env: MOC
+namespaces:
+  - enable_monitoring: false
+    name: testproject
+project_description: This is the configuration for a sample project / app to onboard
+target_cluster: Smaug
+team_name: testgroup
+onboarding_issue: https://github.com/operate-first/support/issues/414141
+docs: https://www.operate-first.cloud

--- a/api/testdata/Onboard/withProjectDetails/cluster-scope/base/core/namespaces/testproject/kustomization.yaml
+++ b/api/testdata/Onboard/withProjectDetails/cluster-scope/base/core/namespaces/testproject/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: testproject
+resources:
+    - namespace.yaml
+components:
+    - ../../../../components/limitranges/default
+    - ../../../../components/project-admin-rolebindings/testgroup

--- a/api/testdata/Onboard/withProjectDetails/cluster-scope/base/core/namespaces/testproject/namespace.yaml
+++ b/api/testdata/Onboard/withProjectDetails/cluster-scope/base/core/namespaces/testproject/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: testproject
+    annotations:
+        openshift.io/requester: testgroup
+        op1st/project-owner: testgroup
+        op1st/onboarding-issue: "https://github.com/operate-first/support/issues/414141"
+        op1st/docs: "https://www.operate-first.cloud"

--- a/api/testdata/Onboard/withProjectDetails/cluster-scope/base/user.openshift.io/groups/testgroup/group.yaml
+++ b/api/testdata/Onboard/withProjectDetails/cluster-scope/base/user.openshift.io/groups/testgroup/group.yaml
@@ -1,0 +1,5 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+    name: testgroup
+users: []

--- a/api/testdata/Onboard/withProjectDetails/cluster-scope/base/user.openshift.io/groups/testgroup/kustomization.yaml
+++ b/api/testdata/Onboard/withProjectDetails/cluster-scope/base/user.openshift.io/groups/testgroup/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - group.yaml

--- a/api/testdata/Onboard/withProjectDetails/cluster-scope/components/project-admin-rolebindings/testgroup/kustomization.yaml
+++ b/api/testdata/Onboard/withProjectDetails/cluster-scope/components/project-admin-rolebindings/testgroup/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+    - rbac.yaml

--- a/api/testdata/Onboard/withProjectDetails/cluster-scope/components/project-admin-rolebindings/testgroup/rbac.yaml
+++ b/api/testdata/Onboard/withProjectDetails/cluster-scope/components/project-admin-rolebindings/testgroup/rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: namespace-admin-testgroup
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: admin
+subjects:
+    - apiGroup: rbac.authorization.k8s.io
+      kind: Group
+      name: testgroup

--- a/api/testdata/Onboard/withProjectDetails/cluster-scope/overlays/prod/common/kustomization.yaml
+++ b/api/testdata/Onboard/withProjectDetails/cluster-scope/overlays/prod/common/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../base
+- ../../../base/user.openshift.io/groups/testgroup

--- a/api/testdata/Onboard/withProjectDetails/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/api/testdata/Onboard/withProjectDetails/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../base
+- ../../../../base/core/namespaces/testproject

--- a/cmd/installOperator.go
+++ b/cmd/installOperator.go
@@ -42,7 +42,7 @@ func NewCmdInstallOperator(opfapi *api.API) *cobra.Command {
 				return err
 			}
 
-			if err := opfapi.CreateNamespace(namespace, owner, "", "", true, true); err != nil {
+			if err := opfapi.CreateNamespace(namespace, owner, "", "", true, true, "", ""); err != nil {
 				return err
 			}
 

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -14,7 +14,7 @@ type Namespace struct {
 // "owner" and "displayName" parameters are used to initialize the
 // "openshift.io/requester" and ""openshift.io/display-name"
 // annotations.
-func NewNamespace(name, owner, displayName string) Namespace {
+func NewNamespace(name string, owner string, displayName string, onboardingIssue string, docs string) Namespace {
 	if len(name) == 0 {
 		log.Fatal("a namespace requires a name")
 	}
@@ -34,8 +34,18 @@ func NewNamespace(name, owner, displayName string) Namespace {
 		},
 	}
 	rsrc.Metadata.Annotations["openshift.io/requester"] = owner
+	if len(onboardingIssue) > 0 || len(docs) > 0 {
+		rsrc.Metadata.Annotations["op1st/project-owner"] = owner
+	}
 	if len(displayName) > 0 {
 		rsrc.Metadata.Annotations["openshift.io/display-name"] = displayName
+	}
+
+	if len(onboardingIssue) > 0 {
+		rsrc.Metadata.Annotations["op1st/onboarding-issue"] = onboardingIssue
+	}
+	if len(docs) > 0 {
+		rsrc.Metadata.Annotations["op1st/docs"] = docs
 	}
 
 	return rsrc

--- a/models/onboardconfig.go
+++ b/models/onboardconfig.go
@@ -22,6 +22,8 @@ type OnboardingRequest struct {
 	TargetCluster      string   `yaml:"target_cluster"`
 	TeamName           string   `yaml:"team_name"`
 	Users              []string `yaml:",omitempty"`
+	OnboardingIssue    string   `yaml:"onboarding_issue,omitempty"`
+	Docs               string   `yaml:"docs,omitempty"`
 }
 
 func OnboardRequestFromYAMLPath(path string) (OnboardingRequest, error) {


### PR DESCRIPTION
Namespace api, cmd, model and testdata changes to allow creation of namespace with opf-dashboard related project details.
Onboard api, cmd, model and testdata changes to utilize new namespace changes for gathering related project details.
fixing namespaces tests because some did not test against the namespace resource itself.

Enables implmentation of: https://github.com/operate-first/apps/issues/1802

/cc @HumairAK @4n4nd 